### PR TITLE
Fix columns selection and initial book option within DialogContent

### DIFF
--- a/src/pages/Export/PdfGenerate.jsx
+++ b/src/pages/Export/PdfGenerate.jsx
@@ -593,7 +593,7 @@ function PdfGenerate() {
                         </Typography>
                     </Toolbar>
                 </AppBar>
-                <DialogContent  >
+                <DialogContent sx={{ mt: 1, pt: 0 }}>
                     <DialogContentText>
                         <Typography>
                             {doI18n("pages:content:pick_one_book_export", i18nRef.current)}
@@ -610,7 +610,8 @@ function PdfGenerate() {
                             MenuProps={{
                                 PaperProps: {
                                     style: {
-                                        maxHeight: 200,
+                                        maxHeight: 224,
+                                        minWidth: 250,
                                     },
                                 },
                             }}


### PR DESCRIPTION
The close handler for "Select the number of columns" was changed in a way that inadvertently prevented column changing as it also `setOpen(false);` and changed the window location href as was needed for the other places it was applied.
  
This PR fixes #2 by giving "Select the number of columns" a separate close handler.

| Starting state | 1 | 3 |
|---|---|---|
| <img width="351" height="127" alt="image" src="https://github.com/user-attachments/assets/fef26dde-3dbf-4143-8626-bdda48bd13cb" /> | <img width="357" height="133" alt="image" src="https://github.com/user-attachments/assets/3a0d530f-cfb7-4187-9c2e-ab6e43d5f2de" /> | <img width="377" height="139" alt="image" src="https://github.com/user-attachments/assets/f4e81eac-b6aa-4b6f-930c-4fb358340fcf" /> |
