### PR TITLE
Fix fragile bookCode extraction from USFM

### DIFF
--- a/src/pages/Import/UsfmImport.jsx
+++ b/src/pages/Import/UsfmImport.jsx
@@ -122,9 +122,33 @@ function UsfmImport() {
   };
 
   const handleCreateLocalBook = async (localBookContent, repoPath) => {
-    if (!repoBooks.includes(localBookContent.split("toc1")[0].split(" ")[1])) {
+    const localBookCodeLine = localBookContent
+      .split("\n")
+      .filter((l) => l.startsWith("\\id"))[0];
+    if (!localBookCodeLine) {
+      enqueueSnackbar(
+        doI18n(
+          "pages:core-contenthandler_text_translation:no_usfm_id_found",
+          i18nRef.current,
+        ),
+        { variant: "error" },
+      );
+      return;
+    }
+    const localBookCode = localBookCodeLine.split(" ")[1];
+    if (!localBookCode || localBookCode.length !== 3) {
+      enqueueSnackbar(
+        doI18n(
+          "pages:core-contenthandler_text_translation:bad_usfm_id_line",
+          i18nRef.current,
+        ),
+        { variant: "error" },
+      );
+      return;
+    }
+    if (!repoBooks.includes(localBookCode)) {
       const response = await postJson(
-        `/api/burrito/ingredient/raw/${repoPath}?ipath=${`${localBookContent.split("toc1")[0].split(" ")[1]}.usfm`}&update_ingredients`,
+        `/api/burrito/ingredient/raw/${repoPath}?ipath=${`${localBookCode}.usfm`}&update_ingredients`,
         JSON.stringify({ payload: localBookContent }),
         debugRef.current,
       );


### PR DESCRIPTION
The previous version relied on toc being the second line of USFM. There's no guarantee that this will be the case and, with data I was using, the bookcode ended up containing an entire h header complete with backslash which does not make for a neat URL.

The new code proceeds by step and checks each step and should therefore be a lot more robust.